### PR TITLE
WIP Update/i2s audio

### DIFF
--- a/esphome/components/i2s_audio/media_player/__init__.py
+++ b/esphome/components/i2s_audio/media_player/__init__.py
@@ -119,7 +119,7 @@ async def to_code(config):
     # |   |-- WiFi
     cg.add_library("SPI", None)
     cg.add_library("FS", None)
-    cg.add_library("FFat", None)    
+    cg.add_library("FFat", None)
     cg.add_library("SD", None)
     cg.add_library("SD_MMC", None)
     cg.add_library("SPIFFS", None)
@@ -131,7 +131,6 @@ async def to_code(config):
     cg.add_library(
         name="ESP32-audioI2S",
         version=None,
-
         # Note: use a custom fork that removes the length limit on the host parameter in connecttohost()
         repository="https://github.com/shadow578/ESP32-audioI2S.git#remove_host_length_limit",
     )

--- a/esphome/components/i2s_audio/media_player/__init__.py
+++ b/esphome/components/i2s_audio/media_player/__init__.py
@@ -102,7 +102,36 @@ async def to_code(config):
         cg.add(var.set_external_dac_channels(2 if config[CONF_MODE] == "stereo" else 1))
         cg.add(var.set_i2s_comm_fmt_lsb(config[CONF_I2S_COMM_FMT] == "lsb"))
 
+    # Add library dependencies:
+    # ESP32-audioI2S
+    # |-- FFat
+    # |   |-- FS
+    # |-- FS
+    # |-- SD
+    # |   |-- FS
+    # |   |-- SPI
+    # |-- SD_MMC
+    # |   |-- FS
+    # |-- SPIFFS
+    # |   |-- FS
+    # |-- WiFi
+    # |-- WiFiClientSecure
+    # |   |-- WiFi
+    cg.add_library("SPI", None)
+    cg.add_library("FS", None)
+    cg.add_library("FFat", None)    
+    cg.add_library("SD", None)
+    cg.add_library("SD_MMC", None)
+    cg.add_library("SPIFFS", None)
+
+    cg.add_library("WiFi", None)
     cg.add_library("WiFiClientSecure", None)
     cg.add_library("HTTPClient", None)
-    cg.add_library("esphome/ESP32-audioI2S", "2.0.7")
-    cg.add_build_flag("-DAUDIO_NO_SD_FS")
+
+    cg.add_library(
+        name="ESP32-audioI2S",
+        version=None,
+
+        # Note: use a custom fork that removes the length limit on the host parameter in connecttohost()
+        repository="https://github.com/shadow578/ESP32-audioI2S.git#remove_host_length_limit",
+    )

--- a/esphome/components/i2s_audio/media_player/i2s_audio_media_player.cpp
+++ b/esphome/components/i2s_audio/media_player/i2s_audio_media_player.cpp
@@ -21,12 +21,11 @@ void I2SAudioMediaPlayer::control(const media_player::MediaPlayerCall &call) {
       if (this->audio_->isRunning()) {
         this->audio_->stopSong();
       }
-      const bool ok = this->audio_->connecttohost(this->current_url_.value().c_str());
-      if (ok) {
+      if (this->connecttouri_(this->current_url_.value())) {
         this->state = play_state;
       } else {
-        ESP_LOGD(TAG, "failed to start audio");
         this->stop_();
+        ESP_LOGD(TAG, "connecttouri_ failed");
       }
     } else {
       this->start();
@@ -183,20 +182,20 @@ void I2SAudioMediaPlayer::start_() {
 
   this->i2s_state_ = I2S_STATE_RUNNING;
   this->high_freq_.start();
-  this->audio_->setVolumeSteps(255); // use 255 steps for smoother volume control
+  this->audio_->setVolumeSteps(255);  // use 255 steps for smoother volume control
   this->audio_->setVolume(remap<uint8_t, float>(this->volume, 0.0f, 1.0f, 0, this->audio_->maxVolume()));
   if (this->current_url_.has_value()) {
-    const bool ok = this->audio_->connecttohost(this->current_url_.value().c_str());
-    if (ok) {
-      this->state = media_player::MEDIA_PLAYER_STATE_PLAYING;
+    if (this->connecttouri_(this->current_url_.value())) {
       if (this->is_announcement_) {
         this->state = media_player::MEDIA_PLAYER_STATE_ANNOUNCING;
+      } else {
+        this->state = media_player::MEDIA_PLAYER_STATE_PLAYING;
       }
 
       this->publish_state();
     } else {
-      ESP_LOGD(TAG, "failed to start audio");
-      stop_();
+      this->stop_();
+      ESP_LOGD(TAG, "connecttouri_ failed");
     }
   }
 }
@@ -262,6 +261,49 @@ void I2SAudioMediaPlayer::dump_config() {
 #if SOC_I2S_SUPPORTS_DAC
   }
 #endif
+}
+
+bool I2SAudioMediaPlayer::connecttouri_(const std::string uri) {
+  if (this->audio_ == nullptr) {
+    return false;
+  }
+
+  // web stream?
+  if (uri.find("http://", 0) == 0 || uri.find("https://", 0) == 0) {
+    ESP_LOGD(TAG, "ConnectTo WebStream '%s'", uri.c_str());
+    return this->audio_->connecttohost(uri.c_str());
+  }
+
+  // local file?
+  if (uri.find("file://", 0) == 0) {
+    // format: file://<path>
+
+    // TODO: add support for local file playback
+
+    // const std::string path = uri.substr(7);
+    // ESP_LOGD(TAG, "ConnectTo File '%s'", path.c_str());
+    // return this->audio_->connecttoFS(FS, uri.c_str() + 7);
+    return false;
+  }
+
+  // text to speech?
+  if (uri.find("tts://", 0) == 0) {
+    // format: tts://<lang>:<text>
+    const size_t colon = uri.find(':', 6);
+    if (colon == std::string::npos || colon > 10) {
+      // language code is expected to be 2-5 characters
+      ESP_LOGW(TAG, "Invalid TTS URI");
+      return false;
+    }
+
+    const std::string lang = uri.substr(6, colon - 6);
+    const std::string text = uri.substr(colon + 1);
+
+    ESP_LOGD(TAG, "ConnectTo TTS: lang='%s', text='%s'", lang.c_str(), text.c_str());
+    return this->audio_->connecttospeech(text.c_str(), lang.c_str());
+  }
+
+  return false;
 }
 
 }  // namespace i2s_audio

--- a/esphome/components/i2s_audio/media_player/i2s_audio_media_player.cpp
+++ b/esphome/components/i2s_audio/media_player/i2s_audio_media_player.cpp
@@ -119,7 +119,7 @@ void I2SAudioMediaPlayer::unmute_() {
 }
 void I2SAudioMediaPlayer::set_volume_(float volume, bool publish) {
   if (this->audio_ != nullptr)
-    this->audio_->setVolume(remap<uint8_t, float>(volume, 0.0f, 1.0f, 0, 21));
+    this->audio_->setVolume(remap<uint8_t, float>(volume, 0.0f, 1.0f, 0, this->audio_->maxVolume()));
   if (publish)
     this->volume = volume;
 }
@@ -183,7 +183,8 @@ void I2SAudioMediaPlayer::start_() {
 
   this->i2s_state_ = I2S_STATE_RUNNING;
   this->high_freq_.start();
-  this->audio_->setVolume(remap<uint8_t, float>(this->volume, 0.0f, 1.0f, 0, 21));
+  this->audio_->setVolumeSteps(255); // use 255 steps for smoother volume control
+  this->audio_->setVolume(remap<uint8_t, float>(this->volume, 0.0f, 1.0f, 0, this->audio_->maxVolume()));
   if (this->current_url_.has_value()) {
     const bool ok = this->audio_->connecttohost(this->current_url_.value().c_str());
     if (ok) {

--- a/esphome/components/i2s_audio/media_player/i2s_audio_media_player.cpp
+++ b/esphome/components/i2s_audio/media_player/i2s_audio_media_player.cpp
@@ -266,4 +266,9 @@ void I2SAudioMediaPlayer::dump_config() {
 }  // namespace i2s_audio
 }  // namespace esphome
 
+void audio_info(const char *info) {
+  using namespace esphome;
+  ESP_LOGD("audio_info", "%s", info);
+}
+
 #endif  // USE_ESP32_FRAMEWORK_ARDUINO

--- a/esphome/components/i2s_audio/media_player/i2s_audio_media_player.h
+++ b/esphome/components/i2s_audio/media_player/i2s_audio_media_player.h
@@ -60,7 +60,7 @@ class I2SAudioMediaPlayer : public Component, public media_player::MediaPlayer, 
   void play_();
 
   bool connecttouri_(const std::string uri);
-  
+
   I2SState i2s_state_{I2S_STATE_STOPPED};
   std::unique_ptr<Audio> audio_;
 

--- a/esphome/components/i2s_audio/media_player/i2s_audio_media_player.h
+++ b/esphome/components/i2s_audio/media_player/i2s_audio_media_player.h
@@ -59,6 +59,8 @@ class I2SAudioMediaPlayer : public Component, public media_player::MediaPlayer, 
   void stop_();
   void play_();
 
+  bool connecttouri_(const std::string uri);
+  
   I2SState i2s_state_{I2S_STATE_STOPPED};
   std::unique_ptr<Audio> audio_;
 


### PR DESCRIPTION
- update ESP-AudioI2s library to latest version (custom fork that removes url length limit)
- forward audio_info to ESP_LOGD (get more info what is happening in ESP-AudioI2s) 
- increase volume steps to make volume control more smooth
- add support for TTS (tts://[lang]:[text])
- add stub for SD card support (file://[path]) - test in https://github.com/shadow578/esphome/tree/add/i2s_audio_media_player-local-file branch


---

usage:
register external component like this:
```yaml
# use custom implementation for i2s_audio media_player
# uses a fork of the latest ESP32-AudioI2C library version
external_components:
  - source: github://shadow578/esphome@update/i2s-audio
    components:
      - i2s_audio
      - media_player
      - i2s_audio/media_player
    refresh: 0s # update on every build
```

then use i2s_audio media_player as normal.
