### PR TITLE
Add/i2s audio media player local file

### DIFF
--- a/esphome/components/i2s_audio/media_player/__init__.py
+++ b/esphome/components/i2s_audio/media_player/__init__.py
@@ -142,6 +142,6 @@ async def to_code(config):
         name="ESP32-audioI2S",
         version=None,
 
-        # Note: use a custom fork that removes the length limit on the host parameter in connecttohost()
-        repository="https://github.com/shadow578/ESP32-audioI2S.git#remove_host_length_limit",
+        # use close-to latest commit, since tagged versions are fairly irregular...
+        repository="https://github.com/schreibfaul1/ESP32-audioI2S.git#1bc79e547ebb6f917bf82b47bec9b7e6a9b7e314",
     )

--- a/esphome/components/i2s_audio/media_player/i2s_audio_media_player.cpp
+++ b/esphome/components/i2s_audio/media_player/i2s_audio_media_player.cpp
@@ -21,12 +21,11 @@ void I2SAudioMediaPlayer::control(const media_player::MediaPlayerCall &call) {
       if (this->audio_->isRunning()) {
         this->audio_->stopSong();
       }
-      const bool ok = this->audio_->connecttohost(this->current_url_.value().c_str());
-      if (ok) {
+      if (this->connecttouri_(this->current_url_.value())) {
         this->state = play_state;
       } else {
-        ESP_LOGD(TAG, "failed to start audio");
         this->stop_();
+        ESP_LOGD(TAG, "connecttouri_ failed");
       }
     } else {
       this->start();
@@ -183,20 +182,20 @@ void I2SAudioMediaPlayer::start_() {
 
   this->i2s_state_ = I2S_STATE_RUNNING;
   this->high_freq_.start();
-  this->audio_->setVolumeSteps(255); // use 255 steps for smoother volume control
+  this->audio_->setVolumeSteps(255);  // use 255 steps for smoother volume control
   this->audio_->setVolume(remap<uint8_t, float>(this->volume, 0.0f, 1.0f, 0, this->audio_->maxVolume()));
   if (this->current_url_.has_value()) {
-    const bool ok = this->audio_->connecttohost(this->current_url_.value().c_str());
-    if (ok) {
-      this->state = media_player::MEDIA_PLAYER_STATE_PLAYING;
+    if (this->connecttouri_(this->current_url_.value())) {
       if (this->is_announcement_) {
         this->state = media_player::MEDIA_PLAYER_STATE_ANNOUNCING;
+      } else {
+        this->state = media_player::MEDIA_PLAYER_STATE_PLAYING;
       }
 
       this->publish_state();
     } else {
-      ESP_LOGD(TAG, "failed to start audio");
-      stop_();
+      this->stop_();
+      ESP_LOGD(TAG, "connecttouri_ failed");
     }
   }
 }
@@ -262,6 +261,49 @@ void I2SAudioMediaPlayer::dump_config() {
 #if SOC_I2S_SUPPORTS_DAC
   }
 #endif
+}
+
+bool I2SAudioMediaPlayer::connecttouri_(const std::string uri) {
+  if (this->audio_ == nullptr) {
+    return false;
+  }
+
+  // web stream?
+  if (uri.find("http://", 0) == 0 || uri.find("https://", 0) == 0) {
+    ESP_LOGD(TAG, "ConnectTo WebStream '%s'", uri.c_str());
+    return this->audio_->connecttohost(uri.c_str());
+  }
+
+  // local file?
+  if (uri.find("file://", 0) == 0) {
+    // format: file://<path>
+
+    // TODO: add support for local file playback
+
+    // const std::string path = uri.substr(7);
+    // ESP_LOGD(TAG, "ConnectTo File '%s'", path.c_str());
+    // return this->audio_->connecttoFS(FS, uri.c_str() + 7);
+    return false;
+  }
+
+  // text to speech?
+  if (uri.find("tts://", 0) == 0) {
+    // format: tts://<lang>:<text>
+    const size_t colon = uri.find(':', 6);
+    if (colon == std::string::npos || colon > 10) {
+      // language code is expected to be 2-5 characters
+      ESP_LOGW(TAG, "Invalid TTS URI");
+      return false;
+    }
+
+    const std::string lang = uri.substr(6, colon - 6);
+    const std::string text = uri.substr(colon + 1);
+
+    ESP_LOGD(TAG, "ConnectTo TTS: lang='%s', text='%s'", lang.c_str(), text.c_str());
+    return this->audio_->connecttospeech(text.c_str(), lang.c_str());
+  }
+
+  return false;
 }
 
 }  // namespace i2s_audio

--- a/esphome/components/i2s_audio/media_player/i2s_audio_media_player.cpp
+++ b/esphome/components/i2s_audio/media_player/i2s_audio_media_player.cpp
@@ -277,13 +277,20 @@ bool I2SAudioMediaPlayer::connecttouri_(const std::string uri) {
   // local file?
   if (uri.find("file://", 0) == 0) {
     // format: file://<path>
+    if (this->sd_card_parent_ == nullptr) {
+      ESP_LOGW(TAG, "SD Card not configured");
+      return false;
+    }
 
-    // TODO: add support for local file playback
-
-    // const std::string path = uri.substr(7);
-    // ESP_LOGD(TAG, "ConnectTo File '%s'", path.c_str());
-    // return this->audio_->connecttoFS(FS, uri.c_str() + 7);
-    return false;
+    if (!this->sd_card_parent_->is_mounted()) {
+      ESP_LOGW(TAG, "SD card not mounted");
+      return false;
+    }
+    
+    const std::string path = uri.substr(7);
+    
+    ESP_LOGD(TAG, "ConnectTo File '%s'", path.c_str());
+    return this->audio_->connecttoFS(*this->sd_card_parent_->get_fs(), uri.c_str() + 7);
   }
 
   // text to speech?

--- a/esphome/components/i2s_audio/media_player/i2s_audio_media_player.cpp
+++ b/esphome/components/i2s_audio/media_player/i2s_audio_media_player.cpp
@@ -271,6 +271,14 @@ bool I2SAudioMediaPlayer::connecttouri_(const std::string uri) {
   // web stream?
   if (uri.find("http://", 0) == 0 || uri.find("https://", 0) == 0) {
     ESP_LOGD(TAG, "ConnectTo WebStream '%s'", uri.c_str());
+
+    if (uri.size() > 2048) {
+      // ESP32-audioI2S limits the URI to 2048 characters
+      // (since https://github.com/schreibfaul1/ESP32-audioI2S/commit/b1b89a9f64b73b0b171493bf55e6158f37a0bccd)
+      ESP_LOGE(TAG, "WebStream URI too long");
+      return false;
+    }
+
     return this->audio_->connecttohost(uri.c_str());
   }
 

--- a/esphome/components/i2s_audio/media_player/i2s_audio_media_player.h
+++ b/esphome/components/i2s_audio/media_player/i2s_audio_media_player.h
@@ -6,10 +6,11 @@
 
 #include <driver/i2s.h>
 
-#include "esphome/components/media_player/media_player.h"
 #include "esphome/core/component.h"
 #include "esphome/core/gpio.h"
 #include "esphome/core/helpers.h"
+#include "esphome/components/media_player/media_player.h"
+#include "esphome/components/sd_card/sd_card.h"
 
 #include <Audio.h>
 
@@ -23,7 +24,10 @@ enum I2SState : uint8_t {
   I2S_STATE_STOPPING,
 };
 
-class I2SAudioMediaPlayer : public Component, public media_player::MediaPlayer, public I2SAudioOut {
+class I2SAudioMediaPlayer : public Component, 
+                            public media_player::MediaPlayer, 
+                            public I2SAudioOut,
+                            public sd_card::SDCardDevice {
  public:
   void setup() override;
   float get_setup_priority() const override { return esphome::setup_priority::LATE; }

--- a/esphome/components/i2s_audio/media_player/i2s_audio_media_player.h
+++ b/esphome/components/i2s_audio/media_player/i2s_audio_media_player.h
@@ -59,6 +59,8 @@ class I2SAudioMediaPlayer : public Component, public media_player::MediaPlayer, 
   void stop_();
   void play_();
 
+  bool connecttouri_(const std::string uri);
+  
   I2SState i2s_state_{I2S_STATE_STOPPED};
   std::unique_ptr<Audio> audio_;
 

--- a/esphome/components/sd_card/__init__.py
+++ b/esphome/components/sd_card/__init__.py
@@ -1,0 +1,41 @@
+import esphome.codegen as cg
+from esphome.components import spi
+import esphome.config_validation as cv
+
+from esphome.const import CONF_ID
+
+
+CODEOWNERS = ["@shadow578"]
+DEPENDENCIES = ["spi"]
+
+CONF_SD_CARD_ID = "sd_card_id"
+
+sd_card_namespace = cg.esphome_ns.namespace("sd_card")
+
+SDCardComponent = sd_card_namespace.class_("SDCardComponent", cg.Component, spi.SPIDevice)
+
+CONFIG_SCHEMA = cv.All(
+    cv.Schema({
+      cv.GenerateID(): cv.declare_id(SDCardComponent),
+  }).extend(spi.spi_device_schema(cs_pin_required=True)),
+  cv.only_with_arduino
+)
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await spi.register_spi_device(var, config)
+
+    # Add library dependencies:
+    # SD
+    # |-- FS
+    # |-- SPI
+    cg.add_library("SPI", None)
+    cg.add_library("FS", None)
+    cg.add_library("SD", None)
+
+sd_card_id_schema = cv.use_id(SDCardComponent)
+
+async def register_sd_card_device(var, config):
+    parent = await cg.get_variable(config[CONF_SD_CARD_ID])
+    cg.add(var.set_sd_card_parent(parent))

--- a/esphome/components/sd_card/sd_card.cpp
+++ b/esphome/components/sd_card/sd_card.cpp
@@ -1,0 +1,83 @@
+#include "sd_card.h"
+
+#ifdef USE_ARDUINO
+
+#include "esphome/core/log.h"
+
+#include "vfs_api.h"
+#include "FS.h"
+
+namespace esphome {
+namespace sd_card {
+static const char *const TAG = "sd_card";
+
+void SDCardComponent::setup() {
+  ESP_LOGI(TAG, "SD Card Setup");
+  this->spi_setup();
+
+  auto vfs = new VFSImpl();
+  this->fs_ = make_unique<fs::SDFS>(FSImplPtr(vfs));
+
+  if (mount()) {
+    ls();
+  }
+}
+
+void SDCardComponent::dump_config() {
+  LOG_PIN("  CS Pin: ", this->cs_);
+}
+
+bool SDCardComponent::mount() {
+  auto spi = this->parent_->get_interface();
+  if (spi == nullptr) {
+    ESP_LOGE(TAG, "Failed to get SPI interface");
+    return false;
+  }
+
+  this->is_mounted_ = this->fs_->begin(static_cast<InternalGPIOPin*>(this->cs_)->get_pin(), *spi);
+
+  if (this->is_mounted_) {
+    ESP_LOGI(TAG, "SD Card mounted");
+  } else {
+    ESP_LOGW(TAG, "Failed to mount SD Card");
+  }
+
+  return this->is_mounted_;
+}
+
+void SDCardComponent::ls_(std::string path, const bool recursive, int indent) {
+  if (!this->is_mounted_) {
+    return;
+  }
+
+  File root = this->fs_->open(path.c_str());
+  if (!root) {
+    ESP_LOGE(TAG, "Failed to open directory %s", path.c_str());
+    return;
+  }
+
+  ESP_LOGI(TAG, "%*s%s", indent, "", path.c_str());
+  if (!root.isDirectory()) {
+    // can only list files within a directory, so stop here
+    return;
+  }
+  
+  indent++;
+  File child = root.openNextFile();
+  while (child) {
+    ESP_LOGI(TAG, "%*s%s", indent, "", child.name());
+
+    // ls child directories
+    if (recursive && child.isDirectory()) {
+      ls_(child.name(), recursive, indent);
+    }
+
+    // next file
+    child = root.openNextFile();
+  }
+}
+
+} // namespace sd_card
+} // namespace esphome
+
+#endif  // USE_ARDUINO

--- a/esphome/components/sd_card/sd_card.h
+++ b/esphome/components/sd_card/sd_card.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#ifdef USE_ARDUINO
+
+#include "esphome/core/component.h"
+#include "esphome/components/spi/spi.h"
+
+#include <SD.h>
+
+namespace esphome {
+namespace sd_card {
+
+class SDCardComponent : public Component, 
+                        public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW, spi::CLOCK_PHASE_LEADING,
+                              spi::DATA_RATE_4MHZ> {
+public:
+  void setup() override;
+  void dump_config() override;
+
+  /**
+   * @brief get the SDFS instance
+   */
+  fs::SDFS* get_fs() { return fs_.get(); }
+
+  /**
+   * @brief is the filesystem mounted?
+   */
+  bool is_mounted() { return is_mounted_; }
+
+  /**
+   * @brief attempt to mount the filesystem
+   * @return true if successful
+   */
+  bool mount();
+
+  /**
+   * @brief list files and directories in the filesystem
+   * @param path the path to list
+   * @param recursive list subdirectories recursively?
+   * 
+   * @note outputs to ESP_LOGI
+   */
+  void ls(std::string path = "/", const bool recursive = true) { ls_(path, recursive); }
+
+private:
+  void ls_(std::string path, const bool recursive, int indent = 0);
+
+  std::unique_ptr<fs::SDFS> fs_;
+  bool is_mounted_{false};
+};
+
+class SDCardDevice {
+public:
+  void set_sd_card_parent(SDCardComponent *parent) { this->sd_card_parent_ = parent; }
+
+protected:
+  SDCardComponent *sd_card_parent_;
+};
+
+} // namespace sd_card
+} // namespace esphome
+
+#endif  // USE_ARDUINO

--- a/esphome/components/spi/spi.h
+++ b/esphome/components/spi/spi.h
@@ -333,6 +333,8 @@ class SPIComponent : public Component {
   void setup() override;
   void dump_config() override;
 
+  SPIInterface get_interface() { return this->interface_; }
+
  protected:
   GPIOPin *clk_pin_{nullptr};
   GPIOPin *sdi_pin_{nullptr};


### PR DESCRIPTION
- add `sd_card` SPI component
- add support for file://[path] protocol in i2s_audio media_player
- ! updates spi class to add accessor for SPIInterface object pointer !


usage:

```yaml
# use custom implementation for i2s_audio media_player
# uses a fork of the latest ESP32-AudioI2C library version
external_components:
  - source: github://shadow578/esphome@add/i2s_audio_media_player-local-file
    components:
      - i2s_audio
      - media_player
      - i2s_audio/media_player
    refresh: 0s # update on every build

# ...

i2s_audio:
  i2s_lrclk_pin: ${i2s_dac_lrclk_pin}
  i2s_bclk_pin: ${i2s_dac_bclk_pin}

spi:
  id: my_spi
  clk_pin: ${spi_clk_pin}
  mosi_pin: ${spi_mosi_pin}
  miso_pin: ${spi_miso_pin}

sd_card:
  cs_pin: ${spi_cs_pin}
  spi_id: my_spi
  id: my_sd_card

media_player:
  - platform: i2s_audio
    name: ${device_name}.media_player
    id: mediaplayer
    dac_type: external
    i2s_dout_pin: ${i2s_dac_dout_pin}
    i2s_comm_fmt: lsb
    mode: mono
    sd_card_id: my_sd_card
```